### PR TITLE
Add support for newer versions of Sequelize using Lodash 4

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -30,7 +30,7 @@ function attrAccessible(model, role, attributes) {
 }
 
 function attrProtected(model, role) {
-  return _.keys(_.pick(model.attributes, function(attr, name) {
+  return _.keys(_.pickBy(model.attributes, function(attr, name) {
     return !_.isUndefined(attr.access) && ( attr.access === false || attr.access[role] === false );
   }));
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,5 @@
 var Sequelize = require('sequelize'),
-    _ = Sequelize.Utils._;
+    _ = require('lodash');
 
 module.exports = function(target) {
   if (target instanceof Sequelize.Model) {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "homepage": "https://github.com/ackerdev/sequelize-attribute-roles#readme",
   "dependencies": {
+    "lodash": "^4.17.4",
     "sequelize": ">=3.0.0"
   }
 }


### PR DESCRIPTION
Hi there,

I realized today that the version of Sequelize I am using (3.30.4) is not working with your library. I found out that recent versions of Sequelize use Lodash 4. Your library was written when Sequelize was using Lodash 3, whose `_.pick()` method used to take a callback as second param. The method is now called `_.pickBy()` in Lodash 4. That simple change makes everything work again!

I would love if you could merge and deploy a new version of your library so I don't have to pull code from Github. Thank you for your library btw, it's a gem!