### PR TITLE
Sequelize 5

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -12,7 +12,7 @@ module.exports = function(target) {
 }
 
 function createHook(model) {
-   model.hook('beforeFindAfterOptions', function(options) {
+   model.addHook('beforeFindAfterOptions', function(options) {
     if (options.role) {
       var role = options.role,
           attributes = options.attributes,

--- a/lib/index.js
+++ b/lib/index.js
@@ -30,7 +30,7 @@ function attrAccessible(model, role, attributes) {
 }
 
 function attrProtected(model, role) {
-  return _.keys(_.pickBy(model.attributes, function(attr, name) {
+  return _.keys(_.pickBy(model.rawAttributes, function(attr, name) {
     return !_.isUndefined(attr.access) && ( attr.access === false || attr.access[role] === false );
   }));
 }


### PR DESCRIPTION
I am in the process of upgrading to Sequelize v5:

- The `model.hook()` method deprecated since v4 has now been removed. Its replacement is `model.addHook()` (see http://docs.sequelizejs.com/manual/upgrade-to-v5.html). 
- The `model.attributes` property has also been removed and replaced by `model.rawAttributes`.

This change should be fully backward compatible: 

- The `model.addHook()` method has been around since Sequelize v3 (see https://sequelize.readthedocs.io/en/v3/api/hooks/#addhookhooktype-name-fn).
- I don't know exactly when `model.rawAttributes` became available, but I've tested this change with Sequelize v4 and it seems to be working fine.
